### PR TITLE
Initial version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(v4l2_cam)
+
+option(FORTIFY "Fortify GCC compilation" OFF)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_FLAGS_RELEASE "-Ofast -DNDEBUG")
+set(ROSLINT_CPP_OPTS "--filter=+,-build/c++11")  # https://github.com/ros/roslint/issues/56
+add_compile_options(-Wall -Wextra)
+if (FORTIFY)
+  add_compile_options(-fstack-protector-all -Wstack-protector --param ssp-buffer-size=4 -D_FORTIFY_SOURCE=2 -O2 -g)
+endif()
+
+find_package(catkin REQUIRED COMPONENTS
+  image_transport message_generation nodelet roscpp roslib roslint sensor_msgs std_msgs
+)
+
+roslint_cpp(include/v4l2_cam/camera.h src/v4l2_cam/camera.cpp src/v4l2_cam_nodelet.cpp)
+roslint_add_test()
+
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if you package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package()
+
+include_directories(
+  SYSTEM ${catkin_INCLUDE_DIRS}
+  include
+)
+
+add_library(v4l2_cam_nodelet
+  src/v4l2_cam_nodelet.cpp
+  src/v4l2_cam/camera.cpp
+)
+
+target_link_libraries(v4l2_cam_nodelet
+  ${catkin_LIBRARIES}
+)

--- a/include/v4l2_cam/camera.h
+++ b/include/v4l2_cam/camera.h
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 ThundeRatz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef V4L2_CAM_CAMERA_H
+#define V4L2_CAM_CAMERA_H
+
+#include <image_transport/image_transport.h>
+
+#include <string>
+#include <vector>
+
+namespace v4l2_cam
+{
+
+class Camera
+{
+ public:
+  class V4L2Image : public sensor_msgs::Image
+  {
+   public:
+    V4L2Image(Camera& camera, int buffer_index) : camera(camera), buffer_index(buffer_index)
+    {}
+
+    virtual ~V4L2Image()
+    {
+      camera.enqueue(buffer_index);
+    }
+
+   private:
+    Camera& camera;
+    int buffer_index;
+  };
+  explicit Camera(const std::string& device);
+  ~Camera();
+  void set_format(const std::string& fourcc, unsigned width, unsigned height);
+  void set_framerate(unsigned numerator, unsigned denominator);
+  const boost::shared_ptr<V4L2Image> capture();
+  void enqueue(int index);
+
+ private:
+  class Buffer
+  {
+   public:
+    uint8_t *start;
+    size_t length;
+  };
+  int fd_;
+  unsigned bytesperline, width, height;
+  std::vector<Buffer> buffers;
+
+  void setup_transfer();
+  boost::shared_ptr<V4L2Image> empty_image(int buffer_index);
+  void list_controls();
+  int print_control(struct v4l2_query_ext_ctrl *query_ext_ctrl);
+  void enumerate_menu(const struct v4l2_query_ext_ctrl *query_ext_ctrl);
+  void enumerate_integer_menu(const struct v4l2_query_ext_ctrl *query_ext_ctrl);
+  int query_menu(struct v4l2_querymenu *menu);
+  void list_formats();
+  int print_format(struct v4l2_fmtdesc *fmtdesc);
+};
+
+}  // namespace v4l2_cam
+
+#endif  // V4L2_CAM_CAMERA_H

--- a/include/v4l2_cam/safe_ioctl.h
+++ b/include/v4l2_cam/safe_ioctl.h
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 ThundeRatz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef V4L2_CAM_SAFE_IOCTL_H
+#define V4L2_CAM_SAFE_IOCTL_H
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#ifndef TEMP_FAILURE_RETRY
+// Taken from Android source code
+#define TEMP_FAILURE_RETRY(exp) ({       \
+  typeof(exp) _rc;                       \
+  do                                     \
+  {                                      \
+    _rc = (exp);                         \
+  }                                      \
+  while (_rc == -1 && errno == EINTR);   \
+  _rc;                                   \
+})
+#endif
+
+#define safe_ioctl(fd, request, ...) do {                         \
+  if (TEMP_FAILURE_RETRY(ioctl(fd, request, __VA_ARGS__)) == -1)  \
+  {                                                               \
+    perror(#request); close(fd); exit(-1);                        \
+  }                                                               \
+} while (0)
+
+#endif  // V4L2_CAM_SAFE_IOCTL_H

--- a/nodelet_plugins.xml
+++ b/nodelet_plugins.xml
@@ -1,0 +1,5 @@
+<library path="lib/libv4l2_cam_nodelet">
+  <class name="v4l2_cam/V4L2CamNodelet" type="v4l2_cam::V4L2CamNodelet" base_class_type="nodelet::Nodelet">
+    <description>v4l2_cam nodelet.</description>
+  </class>
+</library>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<package>
+  <name>v4l2_cam</name>
+  <version>0.0.1</version>
+  <description>V4L2 interface with video cameras</description>
+
+  <maintainer email="tiago.shibata@thunderatz.org">Tiago Koji Castro Shibata</maintainer>
+  <author email="tiago.shibata@thunderatz.org">Tiago Koji Castro Shibata</author>
+
+  <license>MIT</license>
+  <url type="website">http://thunderatz.org</url>
+  <url type="repository">https://github.com/ThundeRatz/ros_v4l2_cam</url>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <build_depend>image_transport</build_depend>
+  <build_depend>message_generation</build_depend>
+  <build_depend>nodelet</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>roslint</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+
+  <run_depend>image_transport</run_depend>
+  <run_depend>message_runtime</run_depend>
+  <run_depend>nodelet</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+
+  <export>
+    <nodelet plugin="${prefix}/nodelet_plugins.xml" />
+  </export>
+</package>

--- a/src/v4l2_cam/camera.cpp
+++ b/src/v4l2_cam/camera.cpp
@@ -1,0 +1,415 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 ThundeRatz
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+#include <fcntl.h>
+#include <linux/videodev2.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <ros/ros.h>
+#include <sensor_msgs/image_encodings.h>
+#include <string>
+
+#include "v4l2_cam/camera.h"
+#include "v4l2_cam/safe_ioctl.h"
+
+
+namespace
+{
+// Conversions taken from:
+// https://github.com/philips/libv4l/blob/master/libv4lconvert/rgbyuv.c#L84
+inline uint8_t crop(int x)
+{
+  return x > 255 ? 255 : x < 0 ? 0 : x;
+}
+
+inline uint8_t yCr2r(int y, int cr)
+{
+  return crop(y + (((cr - 128) * 1436) >> 10));
+}
+
+inline uint8_t yCbCr2g(int y, int u, int v)
+{
+  return crop(y - (((u - 128) * 352 + (v - 128) * 731) >> 10));
+}
+
+inline uint8_t yCb2b(int y, int cb)
+{
+  return crop(y + (((cb - 128) * 1814) >> 10));
+}
+
+void perror_quit(const std::string& msg)
+{
+  perror(msg.c_str());
+  exit(-1);
+}
+}  // namespace
+
+namespace v4l2_cam
+{
+const std::string ctrl_type[] =
+{
+  "INVALID", "INTEGER", "BOOLEAN", "MENU", "INTEGER_MENU", "BITMASK", "BUTTON", "INTEGER64", "STRING", "CTRL_CLASS",
+  "U8", "U16", "U32"
+};
+
+Camera::Camera(const std::string& device)
+{
+  fd_ = open(device.c_str(), O_RDWR);
+  if (-1 == fd_)
+    perror_quit("open");
+
+  struct v4l2_capability cap;
+  safe_ioctl(fd_, VIDIOC_QUERYCAP, &cap);
+  if (!(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE))
+  {
+    ROS_ERROR("Device does not support video capture");
+    exit(-1);
+  }
+
+  if (!(cap.capabilities & V4L2_CAP_STREAMING))
+  {
+    ROS_ERROR("Device does not support streaming I/O");
+    exit(-1);
+  }
+
+  v4l2_priority priority = V4L2_PRIORITY_RECORD;
+  safe_ioctl(fd_, VIDIOC_S_PRIORITY, &priority);
+
+  list_controls();
+  list_formats();
+  set_format("YUYV", 640, 480);
+  set_framerate(1, 10);
+  setup_transfer();
+}
+
+Camera::~Camera()
+{
+  for (auto &x : buffers)
+    munmap(x.start, x.length);
+  const int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  safe_ioctl(fd_, VIDIOC_STREAMOFF, &type);
+}
+
+void Camera::set_format(const std::string& fourcc, unsigned width, unsigned height)
+{
+  ROS_ASSERT(fourcc.size() == 4);
+
+  struct v4l2_format format = {};
+  format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  format.fmt.pix.width = width;
+  format.fmt.pix.height = height;
+  format.fmt.pix.pixelformat = v4l2_fourcc(fourcc[0], fourcc[1], fourcc[2], fourcc[3]);
+  format.fmt.pix.field = V4L2_FIELD_INTERLACED;
+
+  safe_ioctl(fd_, VIDIOC_S_FMT, &format);
+  if (format.fmt.pix.width != width || format.fmt.pix.height != height)
+    ROS_WARN_STREAM("Driver rejected " << width << "x" << height << " and used "
+                    << format.fmt.pix.width << "x" << format.fmt.pix.height << " instead");
+  this->width = format.fmt.pix.width;
+  this->height = format.fmt.pix.height;
+  bytesperline = format.fmt.pix.bytesperline;
+}
+
+void Camera::set_framerate(unsigned numerator, unsigned denominator)
+{
+  struct v4l2_streamparm streamparm = {};
+  streamparm.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  safe_ioctl(fd_, VIDIOC_G_PARM, &streamparm);
+  if (!(streamparm.parm.capture.capability & V4L2_CAP_TIMEPERFRAME))
+  {
+    ROS_WARN("V4L2_CAP_TIMEPERFRAME not supported by driver, leaving frame rate unchanged");
+    return;
+  }
+  streamparm.parm.capture.timeperframe.numerator = numerator;
+  streamparm.parm.capture.timeperframe.denominator = denominator;
+  safe_ioctl(fd_, VIDIOC_S_PARM, &streamparm);
+  if (streamparm.parm.capture.timeperframe.numerator != numerator ||
+      streamparm.parm.capture.timeperframe.denominator != denominator)
+  {
+    ROS_WARN_STREAM("Driver rejected " <<numerator << "/" << denominator << "s per frame and used "
+                    << streamparm.parm.capture.timeperframe.numerator << "/"
+                    << streamparm.parm.capture.timeperframe.denominator << "s instead");
+  }
+}
+
+void Camera::setup_transfer()
+{
+  struct v4l2_requestbuffers reqbuf = {};
+  reqbuf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  reqbuf.memory = V4L2_MEMORY_MMAP;
+  reqbuf.count = 2;
+
+  safe_ioctl(fd_, VIDIOC_REQBUFS, &reqbuf);
+  ROS_ASSERT(reqbuf.count >= 2);
+
+  buffers.resize(reqbuf.count);
+
+  for (unsigned i = 0; i < reqbuf.count; i++)
+  {
+    struct v4l2_buffer buffer = {};
+
+    buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+    buffer.memory = V4L2_MEMORY_MMAP;
+    buffer.index = i;
+
+    safe_ioctl(fd_, VIDIOC_QUERYBUF, &buffer);
+
+    buffers[i].length = buffer.length;
+    buffers[i].start = static_cast<uint8_t *>(mmap(NULL, buffer.length, PROT_READ | PROT_WRITE,
+                                                   MAP_SHARED, fd_, buffer.m.offset));
+
+    if (MAP_FAILED == buffers[i].start)
+      perror_quit("mmap");
+  }
+
+  for (unsigned i = 0; i < reqbuf.count; i++)
+    enqueue(i);
+
+  const int type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  safe_ioctl(fd_, VIDIOC_STREAMON, &type);
+}
+
+const boost::shared_ptr<Camera::V4L2Image> Camera::capture()
+{
+  struct v4l2_buffer buffer = {};
+  buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  buffer.memory = V4L2_MEMORY_MMAP;
+  safe_ioctl(fd_, VIDIOC_DQBUF, &buffer);
+  ROS_ASSERT(buffer.flags & V4L2_BUF_FLAG_MAPPED);
+  ROS_ASSERT(!(buffer.flags & V4L2_BUF_FLAG_DONE));
+  if (buffer.flags & V4L2_BUF_FLAG_ERROR)
+  {
+    ROS_WARN("Camera driver notified buffer error, ignoring frame");
+    return boost::shared_ptr<V4L2Image>();
+  }
+  boost::shared_ptr<V4L2Image> image = empty_image(buffer.index);
+  uint8_t *frame = buffers[buffer.index].start;
+
+  // Linear interpolation
+  int row_pos = 0;
+  float x_scale = static_cast<float>(width - 1) / (448 - 1);
+  float y_scale = static_cast<float>(height - 1) / (448 - 1);
+  ROS_ASSERT(width <= 2 * 448);
+  ROS_ASSERT(width > 448);
+  ROS_ASSERT(!(448 & 1));
+  for (unsigned r = 0; r != height; r++)
+  {
+    for (unsigned c = 0;; c++)
+    {
+      if (c == 448 - 1)
+      {
+        int y = frame[row_pos + 2 * 659], cr = frame[row_pos + 2 * 659 - 1], cb = frame[row_pos + 2 * 659 + 1];
+        image->data.emplace_back(yCr2r(y, cr));
+        image->data.emplace_back(yCbCr2g(y, cb, cr));
+        image->data.emplace_back(yCb2b(y, cb));
+        break;
+      }
+
+      float source_x = c * x_scale;
+      int x = static_cast<int>(source_x);
+      float dx = source_x - x;
+      int r1, g1, b1, r2, g2, b2;
+      if (x & 1)
+      {
+        int y1 = frame[row_pos + 2 * x], cb1 = frame[row_pos + 2 * x - 1], cr1 = frame[row_pos + 2 * x + 1];
+        int y2 = frame[row_pos + 2 * x + 2], cb2 = frame[row_pos + 2 * x + 3], cr2 = frame[row_pos + 2 * x + 5];
+        r1 = yCr2r(y1, cr1), g1 = yCbCr2g(y1, cb1, cr1), b1 = yCb2b(y1, cb1);
+        r2 = yCr2r(y2, cr2), g2 = yCbCr2g(y2, cb2, cr2), b2 = yCb2b(y2, cb2);
+      }
+      else
+      {
+        int y1 = frame[row_pos + 2 * x], cb = frame[row_pos + 2 * x + 1];
+        int y2 = frame[row_pos + 2 * x + 2], cr = frame[row_pos + 2 * x + 3];
+        r1 = yCr2r(y1, cr), g1 = yCbCr2g(y1, cb, cr), b1 = yCb2b(y1, cb);
+        r2 = yCr2r(y2, cr), g2 = yCbCr2g(y2, cb, cr), b2 = yCb2b(y2, cb);
+      }
+      image->data.emplace_back((1 - dx) * r1 + dx * r2);
+      image->data.emplace_back((1 - dx) * g1 + dx * g2);
+      image->data.emplace_back((1 - dx) * b1 + dx * b2);
+    }
+
+    row_pos += bytesperline;
+  }
+  row_pos = 0;
+  for (unsigned r = 0; r != 448; r++)
+  {
+    if (r == 448 - 1)
+      for (unsigned c = 0; c != 448; c++)
+      {
+        image->data[row_pos + 3 * c] = image->data[3 * (480 - 1) * 448 + 3 * c];
+        image->data[row_pos + 3 * c + 1] = image->data[3 * (480 - 1) * 448 + 3 * c + 1];
+        image->data[row_pos + 3 * c + 2] = image->data[3 * (480 - 1) * 448 + 3 * c + 2];
+      }
+    else
+    {
+      float source_y = r * y_scale;
+      int y = static_cast<int>(source_y);
+      float dy = source_y - y;
+      for (int c = 0; c != 448; c++)
+      {
+        image->data[row_pos + 3 * c] = (1 - dy) * image->data[3 * y * 448 + 3 * c] +
+                                       dy * image->data[3 * (y + 1) * 448 + 3 * c];
+        image->data[row_pos + 3 * c + 1] = (1 - dy) * image->data[3 * y * 448 + 3 * c + 1] +
+                                           dy * image->data[3 * (y + 1) * 448 + 3 * c + 1];
+        image->data[row_pos + 3 * c + 2] = (1 - dy) * image->data[3 * y * 448 + 3 * c + 2] +
+                                           dy * image->data[3 * (y + 1) * 448 + 3 * c + 2];
+      }
+    }
+    row_pos += 3 * 448;
+  }
+
+  image->data.resize(3 * 448 * 448);
+  return image;
+}
+
+boost::shared_ptr<Camera::V4L2Image> Camera::empty_image(int buffer_index)
+{
+  boost::shared_ptr<V4L2Image> image(new V4L2Image(*this, buffer_index));
+  image->width = 448;
+  image->height = 448;
+  image->encoding = sensor_msgs::image_encodings::RGB8;
+  image->step = 3 * 448;
+  image->data.reserve(3 * height * 448);  // height * output_width pixels will be used during interpolation
+  return image;
+}
+
+void Camera::enqueue(int index)
+{
+  struct v4l2_buffer buffer = {};
+  buffer.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  buffer.memory = V4L2_MEMORY_MMAP;
+  buffer.index = index;
+  safe_ioctl(fd_, VIDIOC_QBUF, &buffer);
+}
+
+void Camera::list_controls()
+{
+  struct v4l2_query_ext_ctrl query_ext_ctrl = {};
+
+  ROS_INFO("Camera controls:");
+  query_ext_ctrl.id = V4L2_CTRL_FLAG_NEXT_CTRL | V4L2_CTRL_FLAG_NEXT_COMPOUND;
+  while (!print_control(&query_ext_ctrl))
+    query_ext_ctrl.id |= V4L2_CTRL_FLAG_NEXT_CTRL | V4L2_CTRL_FLAG_NEXT_COMPOUND;
+}
+
+int Camera::print_control(struct v4l2_query_ext_ctrl *query_ext_ctrl)
+{
+  if (ioctl(fd_, VIDIOC_QUERY_EXT_CTRL, query_ext_ctrl))
+  {
+    if (errno == EINVAL)
+      return EINVAL;
+    perror_quit("VIDIOC_QUERY_EXT_CTRL");
+  }
+  if (query_ext_ctrl->flags & V4L2_CTRL_FLAG_DISABLED)
+    return 0;
+
+  if (query_ext_ctrl->type == V4L2_CTRL_TYPE_BOOLEAN || query_ext_ctrl->type == V4L2_CTRL_TYPE_BUTTON)
+    ROS_INFO_STREAM("" << query_ext_ctrl->name << " [" << ctrl_type[query_ext_ctrl->type]
+                    << "] - Power-on default " << query_ext_ctrl->default_value);
+  else if (query_ext_ctrl->step > 1)
+    ROS_INFO_STREAM("" << query_ext_ctrl->name << " [" << ctrl_type[query_ext_ctrl->type] << " - "
+                    << query_ext_ctrl->minimum << ".." << query_ext_ctrl->maximum << " with " << query_ext_ctrl->step
+                    << " step] - Power-on default " << query_ext_ctrl->default_value);
+  else
+    ROS_INFO_STREAM("" << query_ext_ctrl->name << " [" << ctrl_type[query_ext_ctrl->type] << " - "
+                    << query_ext_ctrl->minimum << ".." << query_ext_ctrl->maximum << "] - Power-on default "
+                    << query_ext_ctrl->default_value);
+
+  if (query_ext_ctrl->type == V4L2_CTRL_TYPE_MENU)
+    enumerate_menu(query_ext_ctrl);
+  else if (query_ext_ctrl->type == V4L2_CTRL_TYPE_INTEGER_MENU)
+    enumerate_integer_menu(query_ext_ctrl);
+
+  return 0;
+}
+
+void Camera::enumerate_menu(const struct v4l2_query_ext_ctrl *query_ext_ctrl)
+{
+  struct v4l2_querymenu querymenu = {};
+  querymenu.id = query_ext_ctrl->id;
+  for (querymenu.index = query_ext_ctrl->minimum; querymenu.index <= query_ext_ctrl->maximum; querymenu.index++)
+    if (!query_menu(&querymenu))
+      ROS_INFO_STREAM("\t" << querymenu.index << " - " << querymenu.name);
+}
+
+void Camera::enumerate_integer_menu(const struct v4l2_query_ext_ctrl *query_ext_ctrl)
+{
+  struct v4l2_querymenu querymenu = {};
+  querymenu.id = query_ext_ctrl->id;
+  for (querymenu.index = query_ext_ctrl->minimum; querymenu.index <= query_ext_ctrl->maximum; querymenu.index++)
+    if (!query_menu(&querymenu))
+      ROS_INFO_STREAM("\t" << querymenu.index << " - " << querymenu.value);
+}
+
+int Camera::query_menu(struct v4l2_querymenu *querymenu)
+{
+  if (ioctl(fd_, VIDIOC_QUERYMENU, querymenu))
+  {
+    if (errno != EINVAL)
+      perror_quit("VIDIOC_QUERYMENU");
+    return EINVAL;
+  }
+  return 0;
+}
+
+void Camera::list_formats()
+{
+  struct v4l2_fmtdesc fmtdesc = {};
+
+  ROS_INFO("Camera formats:");
+  fmtdesc.index = 0;
+  fmtdesc.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
+  while (!print_format(&fmtdesc))
+    fmtdesc.index++;
+}
+
+int Camera::print_format(struct v4l2_fmtdesc *fmtdesc)
+{
+  if (ioctl(fd_, VIDIOC_ENUM_FMT, fmtdesc))
+  {
+    if (errno != EINVAL)
+      perror_quit("VIDIOC_ENUM_FMT");
+    return EINVAL;
+  }
+  ROS_INFO("%c%c%c%c (%s)", fmtdesc->pixelformat, fmtdesc->pixelformat >> 8, fmtdesc->pixelformat >> 16,
+           fmtdesc->pixelformat >> 24, fmtdesc->description);
+  if (fmtdesc->type == V4L2_BUF_TYPE_VIDEO_CAPTURE_MPLANE)
+    ROS_INFO("\tCapture is multi-plane and not supported");
+  if (fmtdesc->flags & V4L2_FMT_FLAG_COMPRESSED)
+    ROS_INFO("\tCompressed");
+  if (fmtdesc->flags & V4L2_FMT_FLAG_EMULATED)
+    ROS_INFO("\tEmulated compression");
+
+  struct v4l2_format format;
+  ioctl(fd_, VIDIOC_G_FMT, &format);
+
+  return 0;
+}
+
+}  // namespace v4l2_cam

--- a/src/v4l2_cam_nodelet.cpp
+++ b/src/v4l2_cam_nodelet.cpp
@@ -1,0 +1,74 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 ThundeRatz
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include <thread>
+
+#include <image_transport/image_transport.h>
+#include <nodelet/nodelet.h>
+#include <pluginlib/class_list_macros.h>
+#include <ros/console.h>
+#include <ros/package.h>
+#include <ros/ros.h>
+
+#include "v4l2_cam/camera.h"
+
+namespace v4l2_cam
+{
+class V4L2CamNodelet : public nodelet::Nodelet
+{
+ public:
+  virtual void onInit()
+  {
+    ros::NodeHandle& node = getPrivateNodeHandle();
+
+    image_transport::ImageTransport transport(node);
+    publisher = transport.advertise("image", 1);
+
+    camera_thread = new std::thread(image_fetch_thread, &publisher);
+  }
+
+  ~V4L2CamNodelet()
+  {
+    camera_thread->join();
+    delete camera_thread;
+  }
+
+ private:
+  std::thread *camera_thread;
+  image_transport::Publisher publisher;
+
+  static void image_fetch_thread(image_transport::Publisher *publisher)
+  {
+    Camera camera("/dev/video0");
+    while (ros::ok())
+    {
+      const boost::shared_ptr<Camera::V4L2Image> image = camera.capture();
+      if (image != nullptr)
+        publisher->publish(image);
+    }
+  }
+};
+}  // namespace v4l2_cam
+
+PLUGINLIB_EXPORT_CLASS(v4l2_cam::V4L2CamNodelet, nodelet::Nodelet)


### PR DESCRIPTION
Driver para câmera usando Video4Linux2 (a API de vídeo do Linux).

Trabalhei uns dias nele achando que daria para otimizar a parte de captura, transformação (redimensionamento) e conversão (do formato de pixel) mas acho que não valeu muito a pena (o ganho deve ter sido meio insignificante, ainda mais porque o gargalho com YOLO é a GPU e não a CPU). Anyway, o objetivo inicial era repensar um pouco como o pipeline de visão funciona (a câmera captura em YUV ou MJPEG e passa para RGB o frame todo, que depois é redimensionado e passa por reordenação dos canais para entrar na YOLO, e ficaria mais rápido redimensionar antes).

Deve estar um pouco mais rápido que com os outros drivers que testamos ou pelo menos com uso um pouco menor de CPU. O código do jeito que está agora não é muito completo, deixo para vocês fazerem se houver necessidade:

* Deixar o node configurável pelo servidor de parâmetros do ROS: Muitos valores estão hard-coded. Idealmente a gente receberia os parâmetros do ROS para serem facilmente configuráveis (por exemplo, como o [usb_cam](http://wiki.ros.org/usb_cam#Parameters) faz). O [README.md](https://github.com/ThundeRatz/ros_v4l2_cam/commit/4770975f34e6585591350b60f51f177b01aa2204#diff-04c6e90faac2675aa89e2176d2eec7d8R23) tem uma lista de parâmetros que poderiam ser suportados. Atualmente o nodelet lista os parâmetros usando VIDIOC_G_CTRL, faltam as chamadas de VIDIOC_S_CTRL para mudar os parâmetros. A API pode ser encontrada [aqui](https://linuxtv.org/downloads/v4l-dvb-apis/uapi/v4l/vidioc-g-ctrl.html). Uma lista em ordem de prioridade, na minha opinião:
    * Mudar foco fixo e desativar foco automático: Devemos setar o foco mais distante possível e desativar o foco automático. A câmera borra a imagem enquanto tenta focar. Não sei se a câmera da gaiola suporta mudança de foco, mas é interessante deixar certo no nodelet (se precisar mudar de câmera no futuro já funciona como esperado).
    * Balanço de branco e auto exposure: Não testei com eles desativados e não sei se fazem algum mal ativados, vale a pena dar uma testada ou usar os mesmos valores que os outros drivers de câmera usam por padrão.

Outras coisas citadas no README.md podem ser úteis no futuro (eg. seleção do dispositivo, que [está hardcoded](https://github.com/ThundeRatz/ros_v4l2_cam/compare/master...tiagoshibata:master#diff-68b9b5f408fb7b7dda59a601ccfea7feR63), caso tenham duas conectadas no robô), mas não são críticas pra agora.

* Não acho que o node esteja muito otimizado; o [código de redimensionamento](https://github.com/ThundeRatz/ros_v4l2_cam/compare/master...tiagoshibata:master#diff-cd6a51acd27195ad0dfa8569e2a5848cR214) usa interpolação linear, assim como na YOLO, interpolando e convertendo os pixels de YUYV 4:2:2 para RGB 8bpp em uma passada. Acredito que seja mais rápido fazer a interpolação primeiro e depois a conversão para um buffer separado (em duas passadas), já que a interpolação acessaria menos memória (2/3, a relação de YUYV para RGB) e depois a conversão seria feita uma vez por pixel (se feito durante a interpolação, alguns pixels são acessados mais que uma vez).

**TL;DR**: PR grande, mensagem do PR grande, deu muito trabalho, não sei se melhorou muito a performance, algumas tarefas vão sobrar pra vocês.